### PR TITLE
feat: temporarily hide project links until individual project pages are ready

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -781,7 +781,7 @@ details[open] .previous-summary .toggle::before { content: '\2212'; }
 }
 
 .project-links {
-  display: flex;
+  display: none;
   flex-wrap: wrap;
   gap: 0.75rem;
 }


### PR DESCRIPTION
## 🎯 Purpose
Temporarily hide project links (Case Notes, Repo, Runbook, Architecture, Samples, Toolkit, Curriculum, Solution Notes) on the main website until individual project detail pages are ready.

## 🔧 Changes Made
- **Modified**: `assets/css/styles.css`
  - Changed `.project-links` from `display: flex` to `display: none`
  - This hides all project links in the projects section without affecting project descriptions or tags

## ✅ What's Not Affected
- Project titles and descriptions remain visible
- Project tags and filtering functionality unchanged
- Resume file (`resume/resume.html`) - no modifications
- All other website functionality remains intact

## �� Impact
- Users can still view project information and filter by technologies
- Project links are hidden until individual project pages are developed
- Maintains professional appearance while work is in progress

## 📋 Testing
- [x] Project cards display correctly without links
- [x] Project filtering still works
- [x] Resume functionality unchanged
- [x] No broken links or errors

## 🔄 Future Work
- Create individual project detail pages
- Re-enable project links once pages are ready
- Consider adding "Coming Soon" placeholders if needed

---
**Branch**: `feature/hide-project-links`
**Type**: Enhancement